### PR TITLE
feat: allow using string values as seed

### DIFF
--- a/src/lib/methods/fake.ts
+++ b/src/lib/methods/fake.ts
@@ -3,9 +3,10 @@ import type { MapperFn, MapperProperty } from '@fourlights/mapper'
 import type { AnonymizeMethod } from '../types'
 import getMethodOptions from '../utils/getMethodOptions'
 import fuzzysort from 'fuzzysort'
+import makeSeed from '../utils/makeSeed'
 
 export type FakeMethodOptions = {
-	seed?: number
+	seed?: number | string
 	key?: string
 }
 
@@ -18,16 +19,16 @@ class Fake<T> implements AnonymizeMethod<T> {
 	private readonly specialFakerMethods: { name: string; method: any }[] = []
 	private readonly faker: Faker
 
-	constructor(seed?: number) {
+	constructor(seed?: number | string) {
 		this.faker = new Faker({ locale: [en] })
-		if (seed) this.faker.seed(seed)
+		if (seed) this.faker.seed(makeSeed(seed))
 
 		this.specialFakerMethods = this.fakerMethodsMap()
 	}
 
 	generate(key: string, property: MapperProperty<T>) {
 		const options = getMethodOptions<FakeMethodOptions>(property)
-		if (options?.seed) this.faker.seed(options.seed)
+		if (options?.seed) this.faker.seed(makeSeed(options.seed))
 		if (options?.key) key = options.key
 
 		const result = fuzzysort.go(key, this.specialFakerMethods, { key: 'name' })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,7 +22,7 @@ export type AnonymizeMethodOptions =
 	| { method: AnonymizeMethodFn<any>; options?: Record<string, any> }
 
 export type AnonymizePluginOptions = {
-	seed?: number
+	seed?: number | string
 	piiData?: AnonymizeMethodDefinition
 	sensitiveData?: AnonymizeMethodDefinition
 }

--- a/src/lib/utils/makeSeed.test.ts
+++ b/src/lib/utils/makeSeed.test.ts
@@ -1,0 +1,21 @@
+import { name as packageName } from '#package.json'
+import makeSeed from './makeSeed'
+
+describe(packageName, () => {
+	describe('utils', () => {
+		describe('makeSeed', () => {
+			it('should return a deterministic number', () => {
+				expect(makeSeed(1)).toBe(1)
+				expect(makeSeed(1337)).toBe(1337)
+				expect(makeSeed(1337)).toBe(1337)
+				expect(makeSeed(1)).toBe(1)
+			})
+
+			it('should return a number when provided with a string', () => {
+				expect(makeSeed('hello world')).toBe(213106)
+				expect(makeSeed('some other seed')).toBe(3258381)
+				expect(makeSeed('a super special long seed')).toBe(3332240693)
+			})
+		})
+	})
+})

--- a/src/lib/utils/makeSeed.ts
+++ b/src/lib/utils/makeSeed.ts
@@ -1,0 +1,10 @@
+const makeSeed = (seed: string | number): number => {
+	return typeof seed === 'string'
+		? seed
+				.split('')
+				.map((char) => char.charCodeAt(0))
+				.reduce((acc, cur, idx) => acc + (cur << idx), 0)
+		: seed
+}
+
+export default makeSeed


### PR DESCRIPTION
This allows you to get deterministic values based on another property, such as `name`.