### PR TITLE
feat: allow control over redact function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
 				"@faker-js/faker": "^8.4.1",
 				"@leeoniya/ufuzzy": "^1.0.14",
 				"defu": "^6.1.4",
+				"dlv": "^1.1.3",
 				"set-value": "^4.1.0"
 			},
 			"devDependencies": {
 				"@commitlint/config-conventional": "^19.2.2",
 				"@fourlights/mapper": "^1.4.0",
 				"@release-it/conventional-changelog": "^8.0.1",
+				"@types/dlv": "^1.1.4",
 				"husky": "^9.0.11",
 				"oxlint": "^0.3.5",
 				"prettier": "^3.2.5",
@@ -1485,6 +1487,13 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/dlv": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@types/dlv/-/dlv-1.1.4.tgz",
+			"integrity": "sha512-m8KmImw4Jt+4rIgupwfivrWEOnj1LzkmKkqbh075uG13eTQ1ZxHWT6T0vIdSQhLIjQCiR0n0lZdtyDOPO1x2Mw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
@@ -3042,6 +3051,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"license": "MIT"
 		},
 		"node_modules/dot-prop": {
 			"version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@commitlint/config-conventional": "^19.2.2",
 		"@fourlights/mapper": "^1.4.0",
 		"@release-it/conventional-changelog": "^8.0.1",
+		"@types/dlv": "^1.1.4",
 		"husky": "^9.0.11",
 		"oxlint": "^0.3.5",
 		"prettier": "^3.2.5",
@@ -85,6 +86,7 @@
 		"@faker-js/faker": "^8.4.1",
 		"@leeoniya/ufuzzy": "^1.0.14",
 		"defu": "^6.1.4",
+		"dlv": "^1.1.3",
 		"set-value": "^4.1.0"
 	},
 	"publishConfig": {

--- a/src/lib/methods/fake.ts
+++ b/src/lib/methods/fake.ts
@@ -2,7 +2,6 @@ import { en, Faker, type LocaleDefinition } from '@faker-js/faker'
 import uFuzzy from '@leeoniya/ufuzzy'
 
 import type { MapperFn, MapperProperty } from '@fourlights/mapper'
-import { isPlainObject } from '@fourlights/mapper/utils'
 
 import type { AnonymizeMethodFactory, AnonymizePropertyOptions } from '../types'
 import { getMethodOptions } from '../utils/getMethodOptions'
@@ -76,36 +75,6 @@ export class Fake<TData>
       (acc, [name, method]) => acc.concat([{ name, method }]),
       [] as { name: string; method: MapperFn<TData> }[],
     )
-  }
-
-  private shouldTraverse(
-    property: MapperProperty<TData, AnonymizePropertyOptions<TData, FakeMethodOptions<TData>>>,
-  ) {
-    const options = getMethodOptions(property)
-    return options?.traverse ?? true
-  }
-
-  anonymize(
-    key: string,
-    property: MapperProperty<TData, AnonymizePropertyOptions<TData, FakeMethodOptions<TData>>>,
-  ) {
-    const anonymizedProperty: MapperProperty<TData> = {
-      value: (data: TData, _wrappedKey?: string, rowId?: string | number) => {
-        if (isPlainObject(data[key as keyof TData]) && this.shouldTraverse(property))
-          return property.value(data, key, rowId)
-        return this.generate(key, property)(data, key, rowId)
-      },
-    }
-
-    return this.shouldTraverse(property)
-      ? ({
-          ...anonymizedProperty,
-          apply: (row, parentKey, rowId) => {
-            const innerKey = `${rowId!}`.substring(parentKey ? parentKey.length + 1 : 0)
-            return this.generate(innerKey, property)(row, parentKey, rowId)
-          },
-        } as MapperProperty<TData>)
-      : anonymizedProperty
   }
 
   generate(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,8 +8,11 @@ import type { FakeMethodOptions } from './methods/fake'
 import type { RedactMethodOptions } from './methods/redact'
 import type { LocaleDefinition } from '@faker-js/faker'
 
-export type DataTaxonomy = 'pii' | 'sensitive'
+export type DataTaxonomy = 'pii' | 'sensitive' | 'public'
 export type AnonymizeMethods = 'fake' | 'redact' | 'none'
+export type DataClassifications = {
+  [key: string]: DataTaxonomy | DataClassifications | [DataTaxonomy, DataClassifications]
+}
 
 export type AnonymizePropertyFn<TData, TOptions> = (
   key: string,
@@ -17,7 +20,6 @@ export type AnonymizePropertyFn<TData, TOptions> = (
 ) => MapperProperty<TData>
 
 export type AnonymizeMethodFactory<TData, TOptions> = {
-  anonymize: AnonymizePropertyFn<TData, TOptions>
   generate: (
     key: string,
     property: MapperProperty<TData, AnonymizePropertyOptions<TData, TOptions>>,
@@ -30,19 +32,20 @@ export type AnonymizeMethod<TData, TOptions> =
   | AnonymizeMethodOptions<TData>
 export type AnonymizeMethodOptions<T> =
   | { method: 'fake'; options?: FakeMethodOptions<T> }
-  | { method: 'redact'; options?: RedactMethodOptions }
+  | { method: 'redact'; options?: RedactMethodOptions<T> }
   | { method: AnonymizePropertyFn<T, Record<string, any>>; options?: Record<string, any> }
 
 export type AnonymizeOptions<TData, TOptions> = {
   seed?: number | string
   piiData?: AnonymizeMethod<TData, TOptions>
   sensitiveData?: AnonymizeMethod<TData, TOptions>
+  publicData?: AnonymizeMethod<TData, TOptions>
   traverse?: boolean
   locale?: LocaleDefinition | LocaleDefinition[]
 }
 
 export type AnonymizePropertyOptions<TData, TOptions> = MapperPropertyOptions & {
-  classification?: DataTaxonomy
+  classification?: DataTaxonomy | DataClassifications | [DataTaxonomy, DataClassifications]
   anonymize?: AnonymizeMethod<TData, TOptions>
 }
 

--- a/src/lib/utils/withClassification.ts
+++ b/src/lib/utils/withClassification.ts
@@ -3,7 +3,12 @@ import defu from 'defu'
 import type { MapperConfig, MapperFn, MapperProperty } from '@fourlights/mapper'
 import { utils } from '@fourlights/mapper'
 
-import type { AnonymizeMapperConfig, AnonymizePropertyOptions, DataTaxonomy } from '../types'
+import type {
+  AnonymizeMapperConfig,
+  AnonymizePropertyOptions,
+  DataClassifications,
+  DataTaxonomy,
+} from '../types'
 import type { FakeMethodOptions, FakeValueFn } from '../methods/fake'
 import { isType } from './isType'
 
@@ -16,7 +21,7 @@ type AnonymizeMapperPropertyWithClassification<TData, TOptions> =
   | [AnonymizeMapperProperty<TData, TOptions>, DataTaxonomy | undefined]
   | [
       AnonymizeMapperProperty<TData, TOptions>,
-      DataTaxonomy | undefined,
+      DataTaxonomy | DataClassifications | undefined,
       FakeValueFn<TData> | MapperFn<TData> | undefined,
     ]
 
@@ -31,7 +36,7 @@ export function withClassification<TData, TOptions = {}>(
     | MapperConfig<TData>
     | AnonymizeMapperConfig<TData, TOptions>
     | MapperConfigWithClassification<TData, TOptions>,
-  classifications: Record<string, DataTaxonomy> = {},
+  classifications: DataClassifications = {},
 ) {
   const newConfig: MapperConfig<TData, AnonymizePropertyOptions<TData, TOptions>> = {}
 

--- a/tests/unit/methods/redact.test.ts
+++ b/tests/unit/methods/redact.test.ts
@@ -31,5 +31,21 @@ describe(packageName, () => {
       const email = redact.generate('email', property)({})
       expect(email).toBe('XXXXX@XXXXX.com')
     })
+
+    it('should use the provided value function if it exists', () => {
+      const result = new Redact().generate('using-redact-valuefn', {
+        value: () => 'some value',
+        options: {
+          anonymize: {
+            method: 'redact',
+            options: {
+              value: () => 'abcdef',
+            },
+          },
+        },
+      })({})
+
+      expect(result).toBe('abcdef')
+    })
   })
 })


### PR DESCRIPTION
This adds similar functionality to the `redact` function that was recently added to `fake`.
It enables fine grained control over the redaction of objects.

---

Assuming an input object of the following shape:

```
{
  creditCard: {
    number: '4111 1111 1111 1111',
    expiry: '12/27',
    ccv: '123',
    issuer: 'Some CC Issuer',
  }
}
```

With the data taxonomy

```
{
  creditCard: {
    number: 'sensitive',
    ccv: 'sensitive',
    expiry: 'sensitive',
  }
}
```

Will result in:

```
{
  creditCard: {
    ccv: '***',
    expiry: '**/**',
    number: '**** **** **** ****',
    issuer: 'Some CC Issuer',
  }
}
```

Alternatively, you could write the data taxonomy as:

```
{
  creditCard: [
    'sensitive',
    {
      issuer: 'public',
    },
  ]
}
```

which will return the same result:


```
{
  creditCard: {
    ccv: '***',
    expiry: '**/**',
    number: '**** **** **** ****',
    issuer: 'Some CC Issuer',
  }
}
```